### PR TITLE
Refactor Favourites to use FirebaseUid for user ID

### DIFF
--- a/ZenlessZoneZeroWiki/Controllers/FavouritesController.cs
+++ b/ZenlessZoneZeroWiki/Controllers/FavouritesController.cs
@@ -27,7 +27,7 @@ namespace ZenlessZoneZeroWiki.Controllers
         }
 
         // GET: Favourites/Details/5
-        public async Task<IActionResult> Details(int? id)
+        public async Task<IActionResult> Details(string id)
         {
             if (id == null)
             {
@@ -38,7 +38,7 @@ namespace ZenlessZoneZeroWiki.Controllers
                 .Include(f => f.Character)
                 .Include(f => f.User)
                 .Include(f => f.Weapon)
-                .FirstOrDefaultAsync(m => m.UserID == id);
+                .FirstOrDefaultAsync(m => m.FirebaseUid == id);
             if (favourite == null)
             {
                 return NotFound();
@@ -51,7 +51,7 @@ namespace ZenlessZoneZeroWiki.Controllers
         public IActionResult Create()
         {
             ViewData["CharacterID"] = new SelectList(_context.Characters, "CharacterID", "CharacterID");
-            ViewData["UserID"] = new SelectList(_context.Users, "UserID", "Email");
+            ViewData["FirebaseUid"] = new SelectList(_context.Users, "FirebaseUid", "FirebaseUid");
             ViewData["WeaponID"] = new SelectList(_context.Weapons, "WeaponID", "WeaponID");
             return View();
         }
@@ -61,7 +61,7 @@ namespace ZenlessZoneZeroWiki.Controllers
         // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Create([Bind("FavoriteID,UserID,CharacterID,WeaponID,TimeModified")] Favourite favourite)
+        public async Task<IActionResult> Create([Bind("FavoriteID,FirebaseUid,CharacterID,WeaponID,TimeModified")] Favourite favourite)
         {
             if (ModelState.IsValid)
             {
@@ -70,13 +70,13 @@ namespace ZenlessZoneZeroWiki.Controllers
                 return RedirectToAction(nameof(Index));
             }
             ViewData["CharacterID"] = new SelectList(_context.Characters, "CharacterID", "CharacterID", favourite.CharacterID);
-            ViewData["UserID"] = new SelectList(_context.Users, "UserID", "Email", favourite.UserID);
+            ViewData["FirebaseUid"] = new SelectList(_context.Users, "FirebaseUid", "FirebaseUid", favourite.FirebaseUid);
             ViewData["WeaponID"] = new SelectList(_context.Weapons, "WeaponID", "WeaponID", favourite.WeaponID);
             return View(favourite);
         }
 
         // GET: Favourites/Edit/5
-        public async Task<IActionResult> Edit(int? id)
+        public async Task<IActionResult> Edit(string id)
         {
             if (id == null)
             {
@@ -89,7 +89,7 @@ namespace ZenlessZoneZeroWiki.Controllers
                 return NotFound();
             }
             ViewData["CharacterID"] = new SelectList(_context.Characters, "CharacterID", "CharacterID", favourite.CharacterID);
-            ViewData["UserID"] = new SelectList(_context.Users, "UserID", "Email", favourite.UserID);
+            ViewData["FirebaseUid"] = new SelectList(_context.Users, "FirebaseUid", "FirebaseUid", favourite.FirebaseUid);
             ViewData["WeaponID"] = new SelectList(_context.Weapons, "WeaponID", "WeaponID", favourite.WeaponID);
             return View(favourite);
         }
@@ -99,9 +99,9 @@ namespace ZenlessZoneZeroWiki.Controllers
         // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Edit(int id, [Bind("FavoriteID,UserID,CharacterID,WeaponID,TimeModified")] Favourite favourite)
+        public async Task<IActionResult> Edit(string id, [Bind("FavoriteID,FirebaseUid,CharacterID,WeaponID,TimeModified")] Favourite favourite)
         {
-            if (id != favourite.UserID)
+            if (id != favourite.FirebaseUid)
             {
                 return NotFound();
             }
@@ -115,7 +115,7 @@ namespace ZenlessZoneZeroWiki.Controllers
                 }
                 catch (DbUpdateConcurrencyException)
                 {
-                    if (!FavouriteExists(favourite.UserID))
+                    if (!FavouriteExists(favourite.FirebaseUid))
                     {
                         return NotFound();
                     }
@@ -127,13 +127,13 @@ namespace ZenlessZoneZeroWiki.Controllers
                 return RedirectToAction(nameof(Index));
             }
             ViewData["CharacterID"] = new SelectList(_context.Characters, "CharacterID", "CharacterID", favourite.CharacterID);
-            ViewData["UserID"] = new SelectList(_context.Users, "UserID", "Email", favourite.UserID);
+            ViewData["FirebaseUid"] = new SelectList(_context.Users, "FirebaseUid", "FirebaseUid", favourite.FirebaseUid);
             ViewData["WeaponID"] = new SelectList(_context.Weapons, "WeaponID", "WeaponID", favourite.WeaponID);
             return View(favourite);
         }
 
         // GET: Favourites/Delete/5
-        public async Task<IActionResult> Delete(int? id)
+        public async Task<IActionResult> Delete(string id)
         {
             if (id == null)
             {
@@ -144,7 +144,7 @@ namespace ZenlessZoneZeroWiki.Controllers
                 .Include(f => f.Character)
                 .Include(f => f.User)
                 .Include(f => f.Weapon)
-                .FirstOrDefaultAsync(m => m.UserID == id);
+                .FirstOrDefaultAsync(m => m.FirebaseUid == id);
             if (favourite == null)
             {
                 return NotFound();
@@ -156,7 +156,7 @@ namespace ZenlessZoneZeroWiki.Controllers
         // POST: Favourites/Delete/5
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> DeleteConfirmed(int id)
+        public async Task<IActionResult> DeleteConfirmed(string id)
         {
             var favourite = await _context.Favourites.FindAsync(id);
             if (favourite != null)
@@ -168,9 +168,9 @@ namespace ZenlessZoneZeroWiki.Controllers
             return RedirectToAction(nameof(Index));
         }
 
-        private bool FavouriteExists(int id)
+        private bool FavouriteExists(string id)
         {
-            return _context.Favourites.Any(e => e.UserID == id);
+            return _context.Favourites.Any(e => e.FirebaseUid == id);
         }
     }
 }

--- a/ZenlessZoneZeroWiki/Data/ZenlessZoneZeroContext.cs
+++ b/ZenlessZoneZeroWiki/Data/ZenlessZoneZeroContext.cs
@@ -21,7 +21,7 @@ namespace ZenlessZoneZeroWiki.Data
                 .HasKey(u => u.FirebaseUid);
 
             modelBuilder.Entity<Favourite>()
-                .HasKey(f => new { f.UserID, f.CharacterID, f.WeaponID });
+                .HasKey(f => new { f.FirebaseUid, f.CharacterID, f.WeaponID });
 
             base.OnModelCreating(modelBuilder);
         }

--- a/ZenlessZoneZeroWiki/Migrations/20250317185338_CombinedChangesMigration.Designer.cs
+++ b/ZenlessZoneZeroWiki/Migrations/20250317185338_CombinedChangesMigration.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ZenlessZoneZeroWiki.Data;
 
@@ -11,9 +12,11 @@ using ZenlessZoneZeroWiki.Data;
 namespace ZenlessZoneZeroWiki.Migrations
 {
     [DbContext(typeof(ZenlessZoneZeroContext))]
-    partial class ZenlessZoneZeroContextModelSnapshot : ModelSnapshot
+    [Migration("20250317185338_CombinedChangesMigration")]
+    partial class CombinedChangesMigration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ZenlessZoneZeroWiki/Migrations/20250317185338_CombinedChangesMigration.cs
+++ b/ZenlessZoneZeroWiki/Migrations/20250317185338_CombinedChangesMigration.cs
@@ -1,0 +1,90 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ZenlessZoneZeroWiki.Migrations
+{
+    /// <inheritdoc />
+    public partial class CombinedChangesMigration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Favourites_Users_UserFirebaseUid",
+                table: "Favourites");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Favourites",
+                table: "Favourites");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Favourites_UserFirebaseUid",
+                table: "Favourites");
+
+            migrationBuilder.DropColumn(
+                name: "UserID",
+                table: "Favourites");
+
+            migrationBuilder.RenameColumn(
+                name: "UserFirebaseUid",
+                table: "Favourites",
+                newName: "FirebaseUid");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Favourites",
+                table: "Favourites",
+                columns: new[] { "FirebaseUid", "CharacterID", "WeaponID" });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Favourites_Users_FirebaseUid",
+                table: "Favourites",
+                column: "FirebaseUid",
+                principalTable: "Users",
+                principalColumn: "FirebaseUid",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Favourites_Users_FirebaseUid",
+                table: "Favourites");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Favourites",
+                table: "Favourites");
+
+            migrationBuilder.RenameColumn(
+                name: "FirebaseUid",
+                table: "Favourites",
+                newName: "UserFirebaseUid");
+
+            migrationBuilder.AddColumn<int>(
+                name: "UserID",
+                table: "Favourites",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Favourites",
+                table: "Favourites",
+                columns: new[] { "UserID", "CharacterID", "WeaponID" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Favourites_UserFirebaseUid",
+                table: "Favourites",
+                column: "UserFirebaseUid");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Favourites_Users_UserFirebaseUid",
+                table: "Favourites",
+                column: "UserFirebaseUid",
+                principalTable: "Users",
+                principalColumn: "FirebaseUid",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/ZenlessZoneZeroWiki/Views/Favourites/Create.cshtml
+++ b/ZenlessZoneZeroWiki/Views/Favourites/Create.cshtml
@@ -18,8 +18,8 @@
                 <span asp-validation-for="FavoriteID" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="UserID" class="control-label"></label>
-                <select asp-for="UserID" class ="form-control" asp-items="ViewBag.UserID"></select>
+                <label asp-for="FirebaseUid" class="control-label"></label>
+                <select asp-for="FirebaseUid" class="form-control" asp-items="ViewBag.UserID"></select>
             </div>
             <div class="form-group">
                 <label asp-for="CharacterID" class="control-label"></label>

--- a/ZenlessZoneZeroWiki/Views/Favourites/Delete.cshtml
+++ b/ZenlessZoneZeroWiki/Views/Favourites/Delete.cshtml
@@ -44,7 +44,7 @@
     </dl>
     
     <form asp-action="Delete">
-        <input type="hidden" asp-for="UserID" />
+        <input type="hidden" asp-for="FirebaseUid" />
         <input type="hidden" asp-for="CharacterID" />
         <input type="hidden" asp-for="WeaponID" />
         <input type="submit" value="Delete" class="btn btn-danger" /> |

--- a/ZenlessZoneZeroWiki/Views/Favourites/Edit.cshtml
+++ b/ZenlessZoneZeroWiki/Views/Favourites/Edit.cshtml
@@ -17,7 +17,7 @@
                 <input asp-for="FavoriteID" class="form-control" />
                 <span asp-validation-for="FavoriteID" class="text-danger"></span>
             </div>
-            <input type="hidden" asp-for="UserID" />
+            <input type="hidden" asp-for="FirebaseUid" />
             <input type="hidden" asp-for="CharacterID" />
             <input type="hidden" asp-for="WeaponID" />
             <div class="form-group">


### PR DESCRIPTION
Updated FavouritesController to replace UserID with FirebaseUid across all methods. Modified Create, Edit, and Delete views to align with this change. Adjusted the Favourite entity's primary key to use FirebaseUid, CharacterID, and WeaponID. Created migration files to update database constraints and renamed UserFirebaseUid to FirebaseUid. Updated ZenlessZoneZeroContextModelSnapshot to reflect the new Favourites table structure.