### PR TITLE
Update .gitignore for FodyWeavers.xsd and Firebase JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+/ZenlessZoneZeroWiki/zenlesszonezerowikiauth-firebase-adminsdk-fbsvc-0013afcb7c.json


### PR DESCRIPTION
Updated .gitignore to ignore FodyWeavers.xsd and a specific JSON file related to Firebase admin SDK for the ZenlessZoneZeroWiki project.