### PR TITLE
Add admin functionality, views, and role-based restrictions

### DIFF
--- a/ZenlessZoneZeroWiki/BaseController.cs
+++ b/ZenlessZoneZeroWiki/BaseController.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using ZenlessZoneZeroWiki.Data;
+using System.Linq;
+
+namespace ZenlessZoneZeroWiki.Controllers
+{
+    public class BaseController : Controller
+    {
+        protected readonly ZenlessZoneZeroContext _context;
+
+        public BaseController(ZenlessZoneZeroContext context)
+        {
+            _context = context;
+        }
+
+        public override void OnActionExecuting(ActionExecutingContext context)
+        {
+            var firebaseUid = HttpContext.Session.GetString("FirebaseUid");
+            var isAdmin = false;
+            if (!string.IsNullOrEmpty(firebaseUid))
+            {
+                var user = _context.Users.FirstOrDefault(u => u.FirebaseUid == firebaseUid);
+                isAdmin = user?.IsAdmin ?? false;
+            }
+            ViewBag.IsAdmin = isAdmin;
+            base.OnActionExecuting(context);
+        }
+    }
+} 

--- a/ZenlessZoneZeroWiki/Controllers/AccountController.cs
+++ b/ZenlessZoneZeroWiki/Controllers/AccountController.cs
@@ -10,10 +10,10 @@ using ZenlessZoneZeroWiki.Models;
 namespace ZenlessZoneZeroWiki.Controllers;
 
 [Route("[controller]/[action]")]
-public class AccountController : Controller
+public class AccountController : BaseController
 {
     private readonly ZenlessZoneZeroContext _db;
-    public AccountController(ZenlessZoneZeroContext db) => _db = db;
+    public AccountController(ZenlessZoneZeroContext db) : base(db) => _db = db;
 
     /*──────────────────────── LOGIN ───────────────────────*/
 
@@ -70,7 +70,7 @@ public class AccountController : Controller
     public IActionResult Logout()
     {
         HttpContext.Session.Clear();
-        TempData["SuccessMessage"] = "You’ve been logged out.";
+        TempData["SuccessMessage"] = "You've been logged out.";
         return RedirectToAction(nameof(Login));
     }
     [HttpPost("ResendVerification")]
@@ -141,7 +141,6 @@ public class AccountController : Controller
             await SendEmailAsync(m.Email, "Verify your email",
                 $"Please verify your email by clicking the following link: <a href='{verificationLink}'>Verify Email</a>");
 
-
             // mint first key
             var (plain, hashed) = ApiKeyUtil.NewKey();
 
@@ -154,7 +153,8 @@ public class AccountController : Controller
                 LastName = m.LastName,
                 TimeCreated = DateTime.UtcNow,
                 ApiKey = hashed,
-                ApiKeyCreated = DateTime.UtcNow
+                ApiKeyCreated = DateTime.UtcNow,
+                IsAdmin = m.Email.ToLower() == "admin@zenlesszonezero.com" // Set admin for specific email
             };
 
             _db.Users.Add(user);

--- a/ZenlessZoneZeroWiki/Controllers/AdminToolsController.cs
+++ b/ZenlessZoneZeroWiki/Controllers/AdminToolsController.cs
@@ -1,0 +1,22 @@
+using FirebaseAdmin.Auth;
+using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
+
+namespace ZenlessZoneZeroWiki.Controllers
+{
+    public class AdminToolsController : Controller
+    {
+        [HttpGet]
+        public async Task<IActionResult> VerifyAdminEmail()
+        {
+            var user = await FirebaseAuth.DefaultInstance.GetUserByEmailAsync("admin@zenlesszonezero.com");
+            var args = new UserRecordArgs()
+            {
+                Uid = user.Uid,
+                EmailVerified = true
+            };
+            await FirebaseAuth.DefaultInstance.UpdateUserAsync(args);
+            return Content("Admin email has been marked as verified!");
+        }
+    }
+} 

--- a/ZenlessZoneZeroWiki/Controllers/FavouritesController.cs
+++ b/ZenlessZoneZeroWiki/Controllers/FavouritesController.cs
@@ -9,13 +9,13 @@ using System.Threading.Tasks;
 
 namespace ZenlessZoneZeroWiki.Controllers
 {
-    public class FavouritesController : Controller
+    public class FavouritesController : BaseController
     {
         private readonly ZenlessZoneZeroContext _context;
 
         private string firebaseUid = "firebase-uid-123abc";
 
-        public FavouritesController(ZenlessZoneZeroContext context)
+        public FavouritesController(ZenlessZoneZeroContext context) : base(context)
         {
             _context = context;
         }
@@ -62,6 +62,12 @@ namespace ZenlessZoneZeroWiki.Controllers
             if (firebaseUid == null)
             {
                 TempData["ErrorMessage"] = "You're not logged in.";
+                return Redirect(Request.Headers["Referer"].ToString());
+            }
+            var user = await _context.Users.FirstOrDefaultAsync(u => u.FirebaseUid == firebaseUid);
+            if (user != null && user.IsAdmin)
+            {
+                TempData["ErrorMessage"] = "Admins cannot modify favourites.";
                 return Redirect(Request.Headers["Referer"].ToString());
             }
 
@@ -136,6 +142,12 @@ namespace ZenlessZoneZeroWiki.Controllers
             var firebaseUid = GetFirebaseUid();
             if (firebaseUid == null)
                 return Unauthorized();
+            var user = await _context.Users.FirstOrDefaultAsync(u => u.FirebaseUid == firebaseUid);
+            if (user != null && user.IsAdmin)
+            {
+                TempData["ErrorMessage"] = "Admins cannot add favourites.";
+                return RedirectToAction(nameof(FavouriteListView));
+            }
 
             var exists = await _context.Favourites
                 .AnyAsync(f => f.FirebaseUid == firebaseUid && f.CharacterID == id);
@@ -193,6 +205,12 @@ namespace ZenlessZoneZeroWiki.Controllers
             var firebaseUid = GetFirebaseUid();
             if (firebaseUid == null)
                 return Unauthorized();
+            var user = await _context.Users.FirstOrDefaultAsync(u => u.FirebaseUid == firebaseUid);
+            if (user != null && user.IsAdmin)
+            {
+                TempData["ErrorMessage"] = "Admins cannot add favourites.";
+                return RedirectToAction(nameof(FavouriteListView));
+            }
 
             var exists = await _context.Favourites
                 .AnyAsync(f => f.FirebaseUid == firebaseUid && f.WeaponID == id);

--- a/ZenlessZoneZeroWiki/Controllers/HomeController.cs
+++ b/ZenlessZoneZeroWiki/Controllers/HomeController.cs
@@ -1,14 +1,15 @@
 using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using ZenlessZoneZeroWiki.Models;
+using ZenlessZoneZeroWiki.Data;
 
 namespace ZenlessZoneZeroWiki.Controllers;
 
-public class HomeController : Controller
+public class HomeController : BaseController
 {
     private readonly ILogger<HomeController> _logger;
 
-    public HomeController(ILogger<HomeController> logger)
+    public HomeController(ILogger<HomeController> logger, ZenlessZoneZeroContext context) : base(context)
     {
         _logger = logger;
     }

--- a/ZenlessZoneZeroWiki/Controllers/WeaponsController.cs
+++ b/ZenlessZoneZeroWiki/Controllers/WeaponsController.cs
@@ -11,14 +11,9 @@ using ZenlessZoneZeroWiki.Models;
 
 namespace ZenlessZoneZeroWiki.Controllers
 {
-    public class WeaponsController : Controller
+    public class WeaponsController : BaseController
     {
-        private readonly ZenlessZoneZeroContext _context;
-
-        public WeaponsController(ZenlessZoneZeroContext context)
-        {
-            _context = context;
-        }
+        public WeaponsController(ZenlessZoneZeroContext context) : base(context) {}
 
         // GET: Weapons
         public async Task<IActionResult> Index()
@@ -189,6 +184,96 @@ namespace ZenlessZoneZeroWiki.Controllers
             }
 
             return View("WeaponDetailsView", weapon);
+        }
+
+        [HttpGet]
+        public IActionResult AddWeaponView()
+        {
+            if (!ViewBag.IsAdmin)
+            {
+                return RedirectToAction("WeaponListView");
+            }
+            return View();
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> AddWeapon(Weapon weapon)
+        {
+            if (!ViewBag.IsAdmin)
+            {
+                return RedirectToAction("WeaponListView");
+            }
+
+            if (ModelState.IsValid)
+            {
+                _context.Add(weapon);
+                await _context.SaveChangesAsync();
+                return RedirectToAction(nameof(WeaponListView));
+            }
+            return View(weapon);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteWeapon(int id)
+        {
+            if (!ViewBag.IsAdmin)
+            {
+                return RedirectToAction("WeaponListView");
+            }
+            var weapon = await _context.Weapons.FindAsync(id);
+            if (weapon != null)
+            {
+                _context.Weapons.Remove(weapon);
+                await _context.SaveChangesAsync();
+            }
+            return RedirectToAction("WeaponListView");
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> EditWeaponView(int id)
+        {
+            if (!ViewBag.IsAdmin)
+            {
+                return RedirectToAction("WeaponListView");
+            }
+            var weapon = await _context.Weapons.FindAsync(id);
+            if (weapon == null)
+            {
+                return RedirectToAction("WeaponListView");
+            }
+            return View(weapon);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> EditWeapon(Weapon weapon)
+        {
+            if (!ViewBag.IsAdmin)
+            {
+                return RedirectToAction("WeaponListView");
+            }
+            if (ModelState.IsValid)
+            {
+                var existing = await _context.Weapons.FindAsync(weapon.WeaponID);
+                if (existing == null)
+                {
+                    return RedirectToAction("WeaponListView");
+                }
+                // Update only the editable fields
+                existing.Name = weapon.Name;
+                existing.AttackDMG = weapon.AttackDMG;
+                existing.Defence = weapon.Defence;
+                existing.Type = weapon.Type;
+                existing.Description = weapon.Description;
+                existing.ImageUrllink = weapon.ImageUrllink;
+                existing.Price = weapon.Price;
+                existing.Tier = weapon.Tier;
+                await _context.SaveChangesAsync();
+                return RedirectToAction("WeaponListView");
+            }
+            return View("EditWeaponView", weapon);
         }
 
         private bool WeaponExists(int id)

--- a/ZenlessZoneZeroWiki/Data/SeedDatabase.cs
+++ b/ZenlessZoneZeroWiki/Data/SeedDatabase.cs
@@ -26,6 +26,24 @@ namespace ZenlessZoneZeroWiki.Data
             SetDefaultTiers(context);
             SeedRandomPrices(context);
             SetSignatureWeapons(context);
+
+            // Hardcode admin user if not exists
+            if (!context.Users.Any(u => u.IsAdmin))
+            {
+                context.Users.Add(new Models.User
+                {
+                    FirebaseUid = "admin-firebase-uid", 
+                    Username = "admin",
+                    Email = "admin@zenlesszonezero.com",
+                    FirstName = "Admin",
+                    LastName = "User",
+                    TimeCreated = DateTime.UtcNow,
+                    ApiKey = null, // Or generate/set as needed
+                    ApiKeyCreated = null,
+                    IsAdmin = true
+                });
+                context.SaveChanges();
+            }
         }
 
         public static void SeedRandomPrices(ZenlessZoneZeroContext context)

--- a/ZenlessZoneZeroWiki/Dto/UserRegistrationDTO.cs
+++ b/ZenlessZoneZeroWiki/Dto/UserRegistrationDTO.cs
@@ -29,5 +29,6 @@ namespace ZenlessZoneZeroWiki.Dto
         [Compare("Password", ErrorMessage = "Passwords do not match")]
         public string ConfirmPassword { get; set; }
 
+        public bool IsAdmin { get; set; } = false;
     }
 }

--- a/ZenlessZoneZeroWiki/Migrations/20250506043302_AddIsAdminToUser.Designer.cs
+++ b/ZenlessZoneZeroWiki/Migrations/20250506043302_AddIsAdminToUser.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ZenlessZoneZeroWiki.Data;
 
@@ -11,9 +12,11 @@ using ZenlessZoneZeroWiki.Data;
 namespace ZenlessZoneZeroWiki.Migrations
 {
     [DbContext(typeof(ZenlessZoneZeroContext))]
-    partial class ZenlessZoneZeroContextModelSnapshot : ModelSnapshot
+    [Migration("20250506043302_AddIsAdminToUser")]
+    partial class AddIsAdminToUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ZenlessZoneZeroWiki/Migrations/20250506043302_AddIsAdminToUser.cs
+++ b/ZenlessZoneZeroWiki/Migrations/20250506043302_AddIsAdminToUser.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ZenlessZoneZeroWiki.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsAdminToUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsAdmin",
+                table: "Users",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsAdmin",
+                table: "Users");
+        }
+    }
+}

--- a/ZenlessZoneZeroWiki/Models/Character.cs
+++ b/ZenlessZoneZeroWiki/Models/Character.cs
@@ -25,7 +25,7 @@ namespace ZenlessZoneZeroWiki.Models
         // ← Make this the same enum as Weapon.Type:
         public WeaponType AllowedWeaponType { get; set; }
 
-        public ICollection<Favourite> Favourites { get; set; }
+        public ICollection<Favourite> Favourites { get; set; } = new List<Favourite>();
         public decimal Price { get; set; } // Euro price
         public string Tier { get; set; } // Meta tier (S+, S, A, B, C, D)
         public int? SignatureWeaponId { get; set; } // Signature weapon for matching set

--- a/ZenlessZoneZeroWiki/Models/User.cs
+++ b/ZenlessZoneZeroWiki/Models/User.cs
@@ -27,6 +27,8 @@ namespace ZenlessZoneZeroWiki.Models
         public string? ApiKey { get; set; }
         public DateTime? ApiKeyCreated { get; set; }
 
+        public bool IsAdmin { get; set; } = false;
+
         public ICollection<Favourite> Favourites { get; set; } = new List<Favourite>();  // Initialize empty list
         public ShoppingCart ShoppingCart { get; set; } // Persistent shopping cart
     }

--- a/ZenlessZoneZeroWiki/Models/Weapon.cs
+++ b/ZenlessZoneZeroWiki/Models/Weapon.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Collections.Generic;
 
 namespace ZenlessZoneZeroWiki.Models
 {
@@ -15,7 +16,7 @@ namespace ZenlessZoneZeroWiki.Models
         public string Description { get; set; }
         public string ImageUrllink { get; set; }
 
-        public ICollection<Favourite> Favourites { get; set; }
+        public ICollection<Favourite> Favourites { get; set; } = new List<Favourite>();
         public decimal Price { get; set; } // Euro price
         public string Tier { get; set; } // Meta tier (S+, S, A, B, C, D)
     }

--- a/ZenlessZoneZeroWiki/Program.cs
+++ b/ZenlessZoneZeroWiki/Program.cs
@@ -27,6 +27,8 @@ builder.Services.AddControllersWithViews();
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
 
+// Add EmailService as a scoped service for dependency injection
+builder.Services.AddScoped<ZenlessZoneZeroWiki.Services.EmailService>();
 
 var app = builder.Build();
 

--- a/ZenlessZoneZeroWiki/Views/Characters/AddCharacterView.cshtml
+++ b/ZenlessZoneZeroWiki/Views/Characters/AddCharacterView.cshtml
@@ -1,0 +1,182 @@
+@model ZenlessZoneZeroWiki.Models.Character
+
+@{
+    Layout = "~/Views/Shared/_Layout.cshtml";
+    ViewData["Title"] = "Add New Character";
+}
+
+@if (!ViewData.ModelState.IsValid)
+{
+    <div class="alert alert-danger">
+        <strong>Debug: ModelState Errors</strong>
+        <ul>
+        @foreach (var entry in ViewData.ModelState)
+        {
+            foreach (var error in entry.Value.Errors)
+            {
+                <li><strong>@entry.Key</strong>: @error.ErrorMessage</li>
+            }
+        }
+        </ul>
+    </div>
+}
+
+<div class="container py-4">
+    <h2 class="text-white">@ViewData["Title"]</h2>
+    <hr class="text-white" />
+
+    <div class="row">
+        <div class="col-md-8 mx-auto">
+            <div class="card bg-dark text-white">
+                <div class="card-body">
+                    <form asp-action="AddCharacter" method="post" enctype="multipart/form-data">
+                        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="Name" class="control-label"></label>
+                            <input asp-for="Name" class="form-control" />
+                            <span asp-validation-for="Name" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="faction" class="control-label"></label>
+                            <select asp-for="faction" class="form-control">
+                                <option value="">Select Faction</option>
+                                <option value="0">STARS_OF_LYRA</option>
+                                <option value="1">GENTLE_HOUSE</option>
+                                <option value="2">BELOBOG_HEAVY_INDUSTRIES</option>
+                                <option value="3">VICTORIA_HOUSEKEEPING_CO</option>
+                                <option value="4">CRIMINAL_INVESTIGATION_SPECIAL_RESPONSE_TEAM</option>
+                                <option value="5">SONS_OF_CALYDON</option>
+                                <option value="6">SECTION_6</option>
+                                <option value="7">OBOL_SQUAD</option>
+                                <option value="8">CUNNING_HARES</option>
+                            </select>
+                            <span asp-validation-for="faction" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="Element" class="control-label"></label>
+                            <select asp-for="Element" class="form-control">
+                                <option value="">Select Element</option>
+                                <option value="0">ETHER</option>
+                                <option value="1">FIRE</option>
+                                <option value="2">ICE</option>
+                                <option value="3">ELECTRIC</option>
+                                <option value="4">PHYSICAL</option>
+                            </select>
+                            <span asp-validation-for="Element" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="Tier" class="control-label">Tier</label>
+                            <select asp-for="Tier" class="form-control">
+                                <option value="">Select Tier</option>
+                                <option value="S+">S+</option>
+                                <option value="S">S</option>
+                                <option value="A">A</option>
+                                <option value="B">B</option>
+                                <option value="C">C</option>
+                                <option value="D">D</option>
+                            </select>
+                            <span asp-validation-for="Tier" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="ImageUrllink" class="control-label">Image URL</label>
+                            <input asp-for="ImageUrllink" class="form-control" />
+                            <span asp-validation-for="ImageUrllink" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="Description" class="control-label"></label>
+                            <textarea asp-for="Description" class="form-control" rows="4"></textarea>
+                            <span asp-validation-for="Description" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="Price" class="control-label"></label>
+                            <input asp-for="Price" class="form-control" type="number" step="0.01" />
+                            <span asp-validation-for="Price" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="CharacterType" class="control-label"></label>
+                            <select asp-for="CharacterType" class="form-control">
+                                <option value="">Select Character Type</option>
+                                <option value="0">ATTACK</option>
+                                <option value="1">DEFENCE</option>
+                                <option value="2">SUPPORT</option>
+                                <option value="3">ANOMALY</option>
+                                <option value="4">STUN</option>
+                            </select>
+                            <span asp-validation-for="CharacterType" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="HP" class="control-label"></label>
+                            <input asp-for="HP" class="form-control" type="number" />
+                            <span asp-validation-for="HP" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="Attack" class="control-label"></label>
+                            <input asp-for="Attack" class="form-control" type="number" />
+                            <span asp-validation-for="Attack" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="Defence" class="control-label"></label>
+                            <input asp-for="Defence" class="form-control" type="number" />
+                            <span asp-validation-for="Defence" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="TypeUrllink" class="control-label">Type Image URL</label>
+                            <input asp-for="TypeUrllink" class="form-control" />
+                            <span asp-validation-for="TypeUrllink" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="FactionimageUrllink" class="control-label">Faction Image URL</label>
+                            <input asp-for="FactionimageUrllink" class="form-control" />
+                            <span asp-validation-for="FactionimageUrllink" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="AllowedWeaponType" class="control-label"></label>
+                            <select asp-for="AllowedWeaponType" class="form-control">
+                                <option value="">Select Allowed Weapon Type</option>
+                                <option value="0">ATTACK</option>
+                                <option value="1">DEFENCE</option>
+                                <option value="2">SUPPORT</option>
+                                <option value="3">ANOMALY</option>
+                                <option value="4">STUN</option>
+                            </select>
+                            <span asp-validation-for="AllowedWeaponType" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="SignatureWeaponId" class="control-label"></label>
+                            <input asp-for="SignatureWeaponId" class="form-control" type="number" />
+                            <span asp-validation-for="SignatureWeaponId" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group">
+                            <button type="submit" class="btn btn-success">
+                                <i class="bi bi-plus-circle"></i> Add Character
+                            </button>
+                            <a asp-action="CharacterListView" class="btn btn-secondary">
+                                <i class="bi bi-arrow-left"></i> Back to List
+                            </a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+} 

--- a/ZenlessZoneZeroWiki/Views/Characters/CharacterListView.cshtml
+++ b/ZenlessZoneZeroWiki/Views/Characters/CharacterListView.cshtml
@@ -5,6 +5,7 @@
     ViewData["Title"] = "Characters";
     var favoritedCharacterIds = Model.FavoritedCharacterIds;
     var isLoggedIn = Context.Session.GetString("AuthToken") != null;
+    var isAdmin = ViewBag.IsAdmin as bool? ?? false;
 }
 
 @section Scripts {
@@ -76,6 +77,13 @@
     <h2 class="text-white">@ViewData["Title"]</h2>
     <hr class="text-white" />
 
+    @if (isAdmin)
+    {
+        <a asp-controller="Characters" asp-action="AddCharacterView" class="btn btn-success mb-3">
+            <i class="bi bi-plus-circle"></i> Add New Character
+        </a>
+    }
+
     <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 g-3">
         @foreach (var character in Model.Characters)
         {
@@ -84,7 +92,7 @@
 
                     <!-- Favorite Star -->
                     <div class="position-absolute" style="top: 1rem; right: 1rem; font-size: 2rem; z-index: 10;">
-                        @if (isLoggedIn)
+                        @if (isLoggedIn && !isAdmin)
                         {
                             <a href="#" onclick="toggleFavourite(event, @character.CharacterID)">
                                 <i id="fav-star-@character.CharacterID"
@@ -93,7 +101,7 @@
                                 </i>
                             </a>
                         }
-                        else
+                        else if (!isLoggedIn)
                         {
                             <a asp-controller="Account" asp-action="Login" asp-route-message="You must Login to favorite. But i bet you already knew that" class="text-light">
                                 <i class="bi bi-star" title="Login to favorite"></i>
@@ -107,12 +115,13 @@
                              class="img-fluid rounded mb-3"
                              style="max-height: 150px; object-fit: cover;" />
                         <h5 class="card-title mb-2">@character.Name</h5>
+                        <div class="mb-2">Price: @string.Format("{0:0.##}", character.Price) €</div>
 
                         <a asp-controller="Characters" asp-action="CharacterDetailsView" asp-route-id="@character.CharacterID"
                            class="neon-button w-100 mb-2">
                             View Details
                         </a>
-                        @if (isLoggedIn)
+                        @if (isLoggedIn && !isAdmin)
                         {
                             <form asp-controller="ShoppingCart" asp-action="AddToCart" method="post" class="d-inline w-100">
                                 <input type="hidden" name="itemType" value="Character" />
@@ -121,6 +130,17 @@
                                     <i class="bi bi-cart-plus"></i> Add to Cart
                                 </button>
                             </form>
+                        }
+                        @if (isAdmin)
+                        {
+                            <form asp-action="DeleteCharacter" method="post" asp-controller="Characters" asp-route-id="@character.CharacterID" style="display:inline;">
+                                <button type="submit" class="btn btn-danger btn-sm mt-2" onclick="return confirm('Are you sure you want to delete this character?');">
+                                    <i class="bi bi-trash"></i> Delete
+                                </button>
+                            </form>
+                            <a asp-action="EditCharacterView" asp-controller="Characters" asp-route-id="@character.CharacterID" class="btn btn-warning btn-sm mt-2">
+                                <i class="bi bi-pencil"></i> Edit
+                            </a>
                         }
                     </div>
                 </div>

--- a/ZenlessZoneZeroWiki/Views/Characters/EditCharacterView.cshtml
+++ b/ZenlessZoneZeroWiki/Views/Characters/EditCharacterView.cshtml
@@ -1,0 +1,151 @@
+@model ZenlessZoneZeroWiki.Models.Character
+
+@{
+    Layout = "~/Views/Shared/_Layout.cshtml";
+    ViewData["Title"] = "Edit Character";
+}
+
+<h2 class="text-white">@ViewData["Title"]</h2>
+<hr class="text-white" />
+
+<div class="container py-4">
+    <div class="row">
+        <div class="col-md-8 mx-auto">
+            <div class="card bg-dark text-white">
+                <div class="card-body">
+                    <form asp-action="EditCharacter" method="post" enctype="multipart/form-data">
+                        <input type="hidden" asp-for="CharacterID" />
+                        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                        <div class="form-group mb-3">
+                            <label asp-for="Name" class="control-label"></label>
+                            <input asp-for="Name" class="form-control" />
+                            <span asp-validation-for="Name" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="faction" class="control-label"></label>
+                            <select asp-for="faction" class="form-control">
+                                <option value="">Select Faction</option>
+                                <option value="0">STARS_OF_LYRA</option>
+                                <option value="1">GENTLE_HOUSE</option>
+                                <option value="2">BELOBOG_HEAVY_INDUSTRIES</option>
+                                <option value="3">VICTORIA_HOUSEKEEPING_CO</option>
+                                <option value="4">CRIMINAL_INVESTIGATION_SPECIAL_RESPONSE_TEAM</option>
+                                <option value="5">SONS_OF_CALYDON</option>
+                                <option value="6">SECTION_6</option>
+                                <option value="7">OBOL_SQUAD</option>
+                                <option value="8">CUNNING_HARES</option>
+                            </select>
+                            <span asp-validation-for="faction" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="Element" class="control-label"></label>
+                            <select asp-for="Element" class="form-control">
+                                <option value="">Select Element</option>
+                                <option value="0">ETHER</option>
+                                <option value="1">FIRE</option>
+                                <option value="2">ICE</option>
+                                <option value="3">ELECTRIC</option>
+                                <option value="4">PHYSICAL</option>
+                            </select>
+                            <span asp-validation-for="Element" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="Tier" class="control-label">Tier</label>
+                            <select asp-for="Tier" class="form-control">
+                                <option value="">Select Tier</option>
+                                <option value="S+">S+</option>
+                                <option value="S">S</option>
+                                <option value="A">A</option>
+                                <option value="B">B</option>
+                                <option value="C">C</option>
+                                <option value="D">D</option>
+                            </select>
+                            <span asp-validation-for="Tier" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="ImageUrllink" class="control-label">Image URL</label>
+                            <input asp-for="ImageUrllink" class="form-control" />
+                            <span asp-validation-for="ImageUrllink" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="Description" class="control-label"></label>
+                            <textarea asp-for="Description" class="form-control" rows="4"></textarea>
+                            <span asp-validation-for="Description" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="Price" class="control-label"></label>
+                            <input asp-for="Price" class="form-control" type="number" step="0.01" value="@string.Format("{0:0.##}", Model.Price)" />
+                            <span asp-validation-for="Price" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="CharacterType" class="control-label"></label>
+                            <select asp-for="CharacterType" class="form-control">
+                                <option value="">Select Character Type</option>
+                                <option value="0">ATTACK</option>
+                                <option value="1">DEFENCE</option>
+                                <option value="2">SUPPORT</option>
+                                <option value="3">ANOMALY</option>
+                                <option value="4">STUN</option>
+                            </select>
+                            <span asp-validation-for="CharacterType" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="HP" class="control-label"></label>
+                            <input asp-for="HP" class="form-control" type="number" />
+                            <span asp-validation-for="HP" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="Attack" class="control-label"></label>
+                            <input asp-for="Attack" class="form-control" type="number" />
+                            <span asp-validation-for="Attack" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="Defence" class="control-label"></label>
+                            <input asp-for="Defence" class="form-control" type="number" />
+                            <span asp-validation-for="Defence" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="TypeUrllink" class="control-label">Type Image URL</label>
+                            <input asp-for="TypeUrllink" class="form-control" />
+                            <span asp-validation-for="TypeUrllink" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="FactionimageUrllink" class="control-label">Faction Image URL</label>
+                            <input asp-for="FactionimageUrllink" class="form-control" />
+                            <span asp-validation-for="FactionimageUrllink" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="AllowedWeaponType" class="control-label"></label>
+                            <select asp-for="AllowedWeaponType" class="form-control">
+                                <option value="">Select Allowed Weapon Type</option>
+                                <option value="0">ATTACK</option>
+                                <option value="1">DEFENCE</option>
+                                <option value="2">SUPPORT</option>
+                                <option value="3">ANOMALY</option>
+                                <option value="4">STUN</option>
+                            </select>
+                            <span asp-validation-for="AllowedWeaponType" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="SignatureWeaponId" class="control-label"></label>
+                            <input asp-for="SignatureWeaponId" class="form-control" type="number" />
+                            <span asp-validation-for="SignatureWeaponId" class="text-danger"></span>
+                        </div>
+                        <div class="form-group">
+                            <button type="submit" class="btn btn-success">
+                                <i class="bi bi-save"></i> Save Changes
+                            </button>
+                            <a asp-action="CharacterListView" class="btn btn-secondary">
+                                <i class="bi bi-arrow-left"></i> Back to List
+                            </a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+} 

--- a/ZenlessZoneZeroWiki/Views/Shared/_Layout.cshtml
+++ b/ZenlessZoneZeroWiki/Views/Shared/_Layout.cshtml
@@ -3,6 +3,7 @@
 
 @{
     var isLoggedIn = Context.Session.GetString("AuthToken") != null;
+    var isAdmin = ViewBag.IsAdmin as bool? ?? false;
 }
 <!DOCTYPE html>
 <html lang="en">
@@ -57,45 +58,47 @@
                         </ul>
                     </li>
 
-                    <li class="nav-item">
-                        <a class="nav-link"
-                           href="@Url.Action("Index", "Api")">API</a>
-                    </li>
-
-                    @if (isLoggedIn)
+                    @if (!isAdmin)
                     {
                         <li class="nav-item">
                             <a class="nav-link"
-                               href="@Url.Action("FavouriteListView", "Favourites")">Favourites</a>
+                               href="@Url.Action("Index", "Api")">API</a>
                         </li>
-                        <li class="nav-item">
-                            <a class="nav-link position-relative" href="@Url.Action("Index", "ShoppingCart")">
-                                <i class="bi bi-cart4"></i> Cart
-                                <span id="cartBadge" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" style="display: none;">
-                                    0
-                                </span>
-                            </a>
-                        </li>
-                        <li class="nav-item dropdown">
-                            <a class="nav-link dropdown-toggle position-relative" href="#" id="notificationsDropdown" role="button"
-                               data-bs-toggle="dropdown" aria-expanded="false">
-                                <i class="bi bi-bell"></i>
-                                <span id="notificationsBadge" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" style="display: none;">
-                                    0
-                                </span>
-                            </a>
-                            <ul class="dropdown-menu dropdown-menu-end dropdown-menu-dark" aria-labelledby="notificationsDropdown" style="min-width: 300px;">
-                                <li><h6 class="dropdown-header">Recent Purchases</h6></li>
-                                <li><div id="purchaseHistory" class="px-3 py-2"></div></li>
-                                <li><hr class="dropdown-divider"></li>
-                                <li>
-                                    <button class="dropdown-item text-center text-primary" id="markAllReadBtn" type="button">
-                                        Mark all as read
-                                    </button>
-                                </li>
-                                <li><a class="dropdown-item text-center" href="@Url.Action("Index", "ShoppingCart")">View All Purchases</a></li>
-                            </ul>
-                        </li>
+                        @if (isLoggedIn)
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link"
+                                   href="@Url.Action("FavouriteListView", "Favourites")">Favourites</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link position-relative" href="@Url.Action("Index", "ShoppingCart")">
+                                    <i class="bi bi-cart4"></i> Cart
+                                    <span id="cartBadge" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" style="display: none;">
+                                        0
+                                    </span>
+                                </a>
+                            </li>
+                            <li class="nav-item dropdown">
+                                <a class="nav-link dropdown-toggle position-relative" href="#" id="notificationsDropdown" role="button"
+                                   data-bs-toggle="dropdown" aria-expanded="false">
+                                    <i class="bi bi-bell"></i>
+                                    <span id="notificationsBadge" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" style="display: none;">
+                                        0
+                                    </span>
+                                </a>
+                                <ul class="dropdown-menu dropdown-menu-end dropdown-menu-dark" aria-labelledby="notificationsDropdown" style="min-width: 300px;">
+                                    <li><h6 class="dropdown-header">Recent Purchases</h6></li>
+                                    <li><div id="purchaseHistory" class="px-3 py-2"></div></li>
+                                    <li><hr class="dropdown-divider"></li>
+                                    <li>
+                                        <button class="dropdown-item text-center text-primary" id="markAllReadBtn" type="button">
+                                            Mark all as read
+                                        </button>
+                                    </li>
+                                    <li><a class="dropdown-item text-center" href="@Url.Action("Index", "ShoppingCart")">View All Purchases</a></li>
+                                </ul>
+                            </li>
+                        }
                     }
                 </ul>
 

--- a/ZenlessZoneZeroWiki/Views/Weapons/AddWeaponView.cshtml
+++ b/ZenlessZoneZeroWiki/Views/Weapons/AddWeaponView.cshtml
@@ -1,0 +1,115 @@
+@model ZenlessZoneZeroWiki.Models.Weapon
+
+@{
+    Layout = "~/Views/Shared/_Layout.cshtml";
+    ViewData["Title"] = "Add New Weapon";
+}
+
+<div class="container py-4">
+    <h2 class="text-white">@ViewData["Title"]</h2>
+    <hr class="text-white" />
+
+    @if (!ViewData.ModelState.IsValid)
+    {
+        <div class="alert alert-danger">
+            <strong>Debug: ModelState Errors</strong>
+            <ul>
+            @foreach (var entry in ViewData.ModelState)
+            {
+                foreach (var error in entry.Value.Errors)
+                {
+                    <li><strong>@entry.Key</strong>: @error.ErrorMessage</li>
+                }
+            }
+            </ul>
+        </div>
+    }
+
+    <div class="row">
+        <div class="col-md-8 mx-auto">
+            <div class="card bg-dark text-white">
+                <div class="card-body">
+                    <form asp-action="AddWeapon" method="post" enctype="multipart/form-data">
+                        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="Name" class="control-label"></label>
+                            <input asp-for="Name" class="form-control" />
+                            <span asp-validation-for="Name" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="Type" class="control-label"></label>
+                            <select asp-for="Type" class="form-control">
+                                <option value="">Select Type</option>
+                                <option value="0">ATTACK</option>
+                                <option value="1">DEFENCE</option>
+                                <option value="2">SUPPORT</option>
+                                <option value="3">ANOMALY</option>
+                                <option value="4">STUN</option>
+                            </select>
+                            <span asp-validation-for="Type" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="AttackDMG" class="control-label"></label>
+                            <input asp-for="AttackDMG" class="form-control" type="number" />
+                            <span asp-validation-for="AttackDMG" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="Defence" class="control-label"></label>
+                            <input asp-for="Defence" class="form-control" type="number" />
+                            <span asp-validation-for="Defence" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="Tier" class="control-label">Tier</label>
+                            <select asp-for="Tier" class="form-control">
+                                <option value="">Select Tier</option>
+                                <option value="S+">S+</option>
+                                <option value="S">S</option>
+                                <option value="A">A</option>
+                                <option value="B">B</option>
+                                <option value="C">C</option>
+                                <option value="D">D</option>
+                            </select>
+                            <span asp-validation-for="Tier" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="ImageUrllink" class="control-label">Image URL</label>
+                            <input asp-for="ImageUrllink" class="form-control" />
+                            <span asp-validation-for="ImageUrllink" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="Description" class="control-label"></label>
+                            <textarea asp-for="Description" class="form-control" rows="4"></textarea>
+                            <span asp-validation-for="Description" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group mb-3">
+                            <label asp-for="Price" class="control-label"></label>
+                            <input asp-for="Price" class="form-control" type="number" step="0.01" />
+                            <span asp-validation-for="Price" class="text-danger"></span>
+                        </div>
+
+                        <div class="form-group">
+                            <button type="submit" class="btn btn-success">
+                                <i class="bi bi-plus-circle"></i> Add Weapon
+                            </button>
+                            <a asp-action="WeaponListView" class="btn btn-secondary">
+                                <i class="bi bi-arrow-left"></i> Back to List
+                            </a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+} 

--- a/ZenlessZoneZeroWiki/Views/Weapons/EditWeaponView.cshtml
+++ b/ZenlessZoneZeroWiki/Views/Weapons/EditWeaponView.cshtml
@@ -1,0 +1,91 @@
+@model ZenlessZoneZeroWiki.Models.Weapon
+
+@{
+    Layout = "~/Views/Shared/_Layout.cshtml";
+    ViewData["Title"] = "Edit Weapon";
+}
+
+<h2 class="text-white">@ViewData["Title"]</h2>
+<hr class="text-white" />
+
+<div class="container py-4">
+    <div class="row">
+        <div class="col-md-8 mx-auto">
+            <div class="card bg-dark text-white">
+                <div class="card-body">
+                    <form asp-action="EditWeapon" method="post" enctype="multipart/form-data">
+                        <input type="hidden" asp-for="WeaponID" />
+                        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                        <div class="form-group mb-3">
+                            <label asp-for="Name" class="control-label"></label>
+                            <input asp-for="Name" class="form-control" />
+                            <span asp-validation-for="Name" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="Type" class="control-label"></label>
+                            <select asp-for="Type" class="form-control">
+                                <option value="">Select Type</option>
+                                <option value="0">ATTACK</option>
+                                <option value="1">DEFENCE</option>
+                                <option value="2">SUPPORT</option>
+                                <option value="3">ANOMALY</option>
+                                <option value="4">STUN</option>
+                            </select>
+                            <span asp-validation-for="Type" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="AttackDMG" class="control-label"></label>
+                            <input asp-for="AttackDMG" class="form-control" type="number" />
+                            <span asp-validation-for="AttackDMG" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="Defence" class="control-label"></label>
+                            <input asp-for="Defence" class="form-control" type="number" />
+                            <span asp-validation-for="Defence" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="Tier" class="control-label">Tier</label>
+                            <select asp-for="Tier" class="form-control">
+                                <option value="">Select Tier</option>
+                                <option value="S+">S+</option>
+                                <option value="S">S</option>
+                                <option value="A">A</option>
+                                <option value="B">B</option>
+                                <option value="C">C</option>
+                                <option value="D">D</option>
+                            </select>
+                            <span asp-validation-for="Tier" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="ImageUrllink" class="control-label">Image URL</label>
+                            <input asp-for="ImageUrllink" class="form-control" />
+                            <span asp-validation-for="ImageUrllink" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="Description" class="control-label"></label>
+                            <textarea asp-for="Description" class="form-control" rows="4"></textarea>
+                            <span asp-validation-for="Description" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="Price" class="control-label"></label>
+                            <input asp-for="Price" class="form-control" type="number" step="0.01" value="@string.Format("{0:0.##}", Model.Price)" />
+                            <span asp-validation-for="Price" class="text-danger"></span>
+                        </div>
+                        <div class="form-group">
+                            <button type="submit" class="btn btn-success">
+                                <i class="bi bi-save"></i> Save Changes
+                            </button>
+                            <a asp-action="WeaponListView" class="btn btn-secondary">
+                                <i class="bi bi-arrow-left"></i> Back to List
+                            </a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+} 

--- a/ZenlessZoneZeroWiki/Views/Weapons/WeaponListView.cshtml
+++ b/ZenlessZoneZeroWiki/Views/Weapons/WeaponListView.cshtml
@@ -4,6 +4,7 @@
     Layout = "~/Views/Shared/_Layout.cshtml";
     ViewData["Title"] = "Weapon List";
     var isLoggedIn = Context.Session.GetString("AuthToken") != null;
+    var isAdmin = ViewBag.IsAdmin as bool? ?? false;
 }
 @section Scripts {
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script> <!-- SweetAlert2 Toast Library -->
@@ -74,6 +75,13 @@
     <h2 class="text-white">@ViewData["Title"]</h2>
     <hr />
 
+    @if (isAdmin)
+    {
+        <a asp-controller="Weapons" asp-action="AddWeaponView" class="btn btn-success mb-3">
+            <i class="bi bi-plus-circle"></i> Add New Weapon
+        </a>
+    }
+
     <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-3">
         @foreach (var weapon in Model.Weapons)
         {
@@ -81,7 +89,7 @@
                 <div class="glow-border">
                     <div class="card weapon-card border-0 glowing-image-container position-relative">
                         <span class="position-absolute" style="top:1rem; right:1rem; font-size:1.5rem; z-index:10;">
-                            @if (isLoggedIn)
+                            @if (isLoggedIn && !isAdmin)
                             {
                                 <a href="#" onclick="toggleWeaponFavourite(event, @weapon.WeaponID)">
                                     <i id="fav-star-@weapon.WeaponID"
@@ -90,7 +98,7 @@
                                     </i>
                                 </a>
                             }
-                            else
+                            else if (!isLoggedIn)
                             {
                                 <a asp-controller="Account" asp-action="Login"
                                    asp-route-message="You must log in to favorite.">
@@ -102,10 +110,11 @@
                         <div class="card-body text-white d-flex flex-column align-items-center p-4">
                             <img src="@weapon.ImageUrllink" alt="@weapon.Name" class="img-fluid rounded mb-3" style="max-height:150px; object-fit:cover;" />
                             <h5 class="card-title mb-2">@weapon.Name</h5>
+                            <div class="mb-2">Price: @string.Format("{0:0.##}", weapon.Price) €</div>
                             <a asp-action="WeaponDetailsView" asp-route-id="@weapon.WeaponID" class="neon-button w-100 mb-2">
                                 View More Details
                             </a>
-                            @if (isLoggedIn)
+                            @if (isLoggedIn && !isAdmin)
                             {
                                 <form asp-controller="ShoppingCart" asp-action="AddToCart" method="post" class="d-inline w-100">
                                     <input type="hidden" name="itemType" value="Weapon" />
@@ -114,6 +123,17 @@
                                         <i class="bi bi-cart-plus"></i> Add to Cart
                                     </button>
                                 </form>
+                            }
+                            @if (isAdmin)
+                            {
+                                <form asp-action="DeleteWeapon" method="post" asp-controller="Weapons" asp-route-id="@weapon.WeaponID" style="display:inline;">
+                                    <button type="submit" class="btn btn-danger btn-sm mt-2" onclick="return confirm('Are you sure you want to delete this weapon?');">
+                                        <i class="bi bi-trash"></i> Delete
+                                    </button>
+                                </form>
+                                <a asp-action="EditWeaponView" asp-controller="Weapons" asp-route-id="@weapon.WeaponID" class="btn btn-warning btn-sm mt-2">
+                                    <i class="bi bi-pencil"></i> Edit
+                                </a>
                             }
                         </div>
                     </div>


### PR DESCRIPTION
Introduced admin-specific features, including the ability to add, edit, and delete characters and weapons. Added the `IsAdmin` property to the `User` model and updated the database schema with a migration. Seeded a hardcoded admin user and integrated Firebase for admin email verification.

Refactored controllers to inherit from a new `BaseController` for shared functionality. Updated views (`AddCharacterView`, `EditCharacterView`, `AddWeaponView`, `EditWeaponView`, etc.) to support admin-specific actions and UI elements. Restricted admin users from accessing regular user features like favorites and shopping cart.

Improved code consistency, fixed typos, and initialized `ICollection` properties in models to prevent null reference issues.